### PR TITLE
Add `sqrt` builtin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ default = ["alpha-keywords"]
 alpha-keywords = []  # Enable 'NaN', 'inf', 'and', 'or'
 unsafe-vars = []     # tinyexpr-style pointer-based variables.
 nightly = []         # Enable features that depend on Rust nightly.
-
+print-func = []      # Enables the builtin print function

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ debug = true
 lto = true
 
 [features]
-default = ["alpha-keywords"]
+default = ["alpha-keywords", "print-func"]
 alpha-keywords = []  # Enable 'NaN', 'inf', 'and', 'or'
 unsafe-vars = []     # tinyexpr-style pointer-based variables.
 nightly = []         # Enable features that depend on Rust nightly.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fasteval2"
-version = "2.0.3"
+version = "2.0.4"
 authors = ["Pasha Podolsky <ppodolsky@me.com>", "Christopher Sebastian <christopher@likebike.com>"]
 license = "MIT"
 readme = "README.md"

--- a/examples/advanced-vars.rs
+++ b/examples/advanced-vars.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), fasteval2::Error> {
             // The `args.get...` code is the same as:
             //     mydata[args[0] as usize]
             // ...but it won't panic if either index is out-of-bounds.
-            "data" => args.get(0).and_then(|f| mydata.get(*f as usize).copied()),
+            "data" => args.first().and_then(|f| mydata.get(*f as usize).copied()),
 
             // A wildcard to handle all undefined names:
             _ => None,

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -68,7 +68,7 @@ fn repl() {
             None => break,
         };
         let mut line = line.trim().to_string();
-        if line == "" {
+        if line.is_empty() {
             continue;
         }
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -30,7 +30,7 @@ use crate::parser::{
     BinaryOp::{
         self, EAdd, EDiv, EExp, EMod, EMul, ESub, EAND, EEQ, EGT, EGTE, ELT, ELTE, ENE, EOR,
     },
-    ExprPair, Expression, PrintFunc,
+    ExprPair, Expression,
     StdFunc::{
         self, EFunc, EFuncACos, EFuncACosH, EFuncASin, EFuncASinH, EFuncATan, EFuncATanH, EFuncAbs,
         EFuncCeil, EFuncCos, EFuncCosH, EFuncE, EFuncFloor, EFuncInt, EFuncLog, EFuncMax, EFuncMin,
@@ -41,6 +41,9 @@ use crate::parser::{
 };
 use crate::slab::{CompileSlab, ParseSlab};
 use crate::Error;
+
+#[cfg(feature = "print-func")]
+use crate::parser::PrintFunc;
 
 /// `true` --> `1.0`,  `false` --> `0.0`
 #[macro_export]
@@ -169,6 +172,7 @@ pub enum Instruction {
     IFuncATanH(InstructionI),
     IFuncSqrt(InstructionI),
 
+    #[cfg(feature = "print-func")]
     IPrintFunc(PrintFunc), // Not optimized (it would be pointless because of i/o bottleneck).
 }
 use crate::{eval_var, EvalNamespace};
@@ -178,8 +182,11 @@ use Instruction::{
     IAdd, IConst, IExp, IFunc, IFuncACos, IFuncACosH, IFuncASin, IFuncASinH, IFuncATan, IFuncATanH,
     IFuncAbs, IFuncCeil, IFuncCos, IFuncCosH, IFuncFloor, IFuncInt, IFuncLog, IFuncMax, IFuncMin,
     IFuncRound, IFuncSign, IFuncSin, IFuncSinH, IFuncSqrt, IFuncTan, IFuncTanH, IInv, IMod, IMul,
-    INeg, INot, IPrintFunc, IVar, IAND, IEQ, IGT, IGTE, ILT, ILTE, INE, IOR,
+    INeg, INot, IVar, IAND, IEQ, IGT, IGTE, ILT, ILTE, INE, IOR,
 };
+
+#[cfg(feature = "print-func")]
+use Instruction::IPrintFunc;
 
 impl Default for Instruction {
     fn default() -> Self {
@@ -752,6 +759,7 @@ impl Compiler for Value {
             Value::EConstant(c) => IConst(*c),
             Value::EUnaryOp(u) => u.compile(pslab, cslab, ns),
             Value::EStdFunc(f) => f.compile(pslab, cslab, ns),
+            #[cfg(feature = "print-func")]
             Value::EPrintFunc(pf) => IPrintFunc(pf.clone()),
         }
     }

--- a/src/evaler.rs
+++ b/src/evaler.rs
@@ -237,10 +237,9 @@ impl Evaler for Expression {
                 };
                 if op == search {
                     let res = op.binaryop_eval(vals.get(i), vals.get(i + 1));
-                    match vals.get_mut(i) {
-                        Some(val_ref) => *val_ref = res,
-                        None => (), // unreachable
-                    };
+                    if let Some(val_ref) = vals.get_mut(i) {
+                        *val_ref = res
+                    }
                     remove_no_panic(vals, i + 1);
                     remove_no_panic(ops, i);
                 }
@@ -255,14 +254,13 @@ impl Evaler for Expression {
                     Some(op) => {
                         if *op == search {
                             let res = op.binaryop_eval(vals.get(i), vals.get(i + 1));
-                            match vals.get_mut(i) {
-                                Some(val_ref) => *val_ref = res,
-                                None => (), // unreachable
-                            };
+                            if let Some(val_ref) = vals.get_mut(i) {
+                                *val_ref = res
+                            }
                             remove_no_panic(vals, i + 1);
                             remove_no_panic(ops, i);
                         } else {
-                            i = i + 1;
+                            i += 1;
                         }
                     }
                 }
@@ -277,14 +275,13 @@ impl Evaler for Expression {
                     Some(op) => {
                         if search.contains(op) {
                             let res = op.binaryop_eval(vals.get(i), vals.get(i + 1));
-                            match vals.get_mut(i) {
-                                Some(val_ref) => *val_ref = res,
-                                None => (), // unreachable
-                            };
+                            if let Some(val_ref) = vals.get_mut(i) {
+                                *val_ref = res
+                            }
                             remove_no_panic(vals, i + 1);
                             remove_no_panic(ops, i);
                         } else {
-                            i = i + 1;
+                            i += 1;
                         }
                     }
                 }

--- a/src/evalns.rs
+++ b/src/evalns.rs
@@ -216,7 +216,7 @@ pub trait Cached {
     fn cache_clear(&mut self);
 }
 
-//// I don't want to put this into the public API until it is needed.
+/// I don't want to put this into the public API until it is needed.
 // pub trait Layered {
 //     fn push(&mut self);
 //     fn pop(&mut self);
@@ -230,6 +230,9 @@ pub trait Cached {
 ///
 pub struct EmptyNamespace;
 
+// I think a reference would be more efficient than a Box, but then I would need to use a funky 'let cb=|n|{}; Namespace::new(&cb)' syntax.  The Box results in a super convenient pass-the-cb-by-value API interface.
+pub type NamespaceCallback<'a> = Box<dyn FnMut(&str, Vec<f64>) -> Option<f64> + 'a>;
+
 /// `CachedCallbackNamespace` is useful when your variable/function lookups are expensive.
 ///
 /// Each variable+args combo will only be looked up once, and then it will be
@@ -239,11 +242,11 @@ pub struct EmptyNamespace;
 ///
 pub struct CachedCallbackNamespace<'a> {
     cache: BTreeMap<String, f64>,
-    cb: Box<dyn FnMut(&str, Vec<f64>) -> Option<f64> + 'a>, // I think a reference would be more efficient than a Box, but then I would need to use a funky 'let cb=|n|{}; Namespace::new(&cb)' syntax.  The Box results in a super convenient pass-the-cb-by-value API interface.
+    cb: NamespaceCallback<'a>,
 }
 
-//// I am commenting these out until I need them in real-life.
-//// (I don't want to add things to the public API until necessary.)
+/// I am commenting these out until I need them in real-life.
+/// (I don't want to add things to the public API until necessary.)
 // pub struct CachedLayeredNamespace<'a> {
 //     caches:Vec<BTreeMap<String,f64>>,
 //     cb    :Box<dyn FnMut(&str, Vec<f64>)->Option<f64> + 'a>,
@@ -300,11 +303,7 @@ pub type StringToCallbackNamespace<'a> = BTreeMap<String, Box<dyn FnMut(Vec<f64>
 impl EvalNamespace for StringToCallbackNamespace<'_> {
     #[inline]
     fn lookup(&mut self, name: &str, args: Vec<f64>, _keybuf: &mut String) -> Option<f64> {
-        if let Some(f) = self.get_mut(name) {
-            Some(f(args))
-        } else {
-            None
-        }
+        self.get_mut(name).map(|f| f(args))
     }
 }
 
@@ -317,11 +316,7 @@ pub type StrToCallbackNamespace<'a> = BTreeMap<&'static str, Box<dyn FnMut(Vec<f
 impl EvalNamespace for StrToCallbackNamespace<'_> {
     #[inline]
     fn lookup(&mut self, name: &str, args: Vec<f64>, _keybuf: &mut String) -> Option<f64> {
-        if let Some(f) = self.get_mut(name) {
-            Some(f(args))
-        } else {
-            None
-        }
+        self.get_mut(name).map(|f| f(args))
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -148,13 +148,14 @@ pub enum StdFunc {
     EFuncASinH(ExpressionI),
     EFuncACosH(ExpressionI),
     EFuncATanH(ExpressionI),
+    EFuncSqrt(ExpressionI),
 }
 #[cfg(feature = "unsafe-vars")]
 use StdFunc::EUnsafeVar;
 use StdFunc::{
     EFunc, EFuncACos, EFuncACosH, EFuncASin, EFuncASinH, EFuncATan, EFuncATanH, EFuncAbs,
     EFuncCeil, EFuncCos, EFuncCosH, EFuncE, EFuncFloor, EFuncInt, EFuncLog, EFuncMax, EFuncMin,
-    EFuncPi, EFuncRound, EFuncSign, EFuncSin, EFuncSinH, EFuncTan, EFuncTanH, EVar,
+    EFuncPi, EFuncRound, EFuncSign, EFuncSin, EFuncSinH, EFuncSqrt, EFuncTan, EFuncTanH, EVar,
 };
 
 /// Represents a `print()` function call in the `fasteval` expression AST.
@@ -1060,6 +1061,16 @@ impl Parser {
                     }))
                 } else {
                     Err(Error::WrongArgs("atanh: expected one arg".to_string()))
+                }
+            }
+            "sqrt" => {
+                if args.len() == 1 {
+                    Ok(EFuncSqrt(match args.pop() {
+                        Some(xi) => xi,
+                        None => return Err(Error::Unreachable),
+                    }))
+                } else {
+                    Err(Error::WrongArgs("sqrt: expected one arg".to_string()))
                 }
             }
 

--- a/tests/compile.rs
+++ b/tests/compile.rs
@@ -3,8 +3,8 @@ use fasteval2::compiler::Instruction::IEvalFunc;
 use fasteval2::compiler::Instruction::{
     self, IAdd, IConst, IExp, IFuncACos, IFuncACosH, IFuncASin, IFuncASinH, IFuncATan, IFuncATanH,
     IFuncAbs, IFuncCeil, IFuncCos, IFuncCosH, IFuncFloor, IFuncInt, IFuncLog, IFuncMax, IFuncMin,
-    IFuncRound, IFuncSign, IFuncSin, IFuncSinH, IFuncTan, IFuncTanH, IInv, IMod, IMul, INeg, INot,
-    IPrintFunc, IVar, IAND, IEQ, IGT, IGTE, ILT, ILTE, INE, IOR,
+    IFuncRound, IFuncSign, IFuncSin, IFuncSinH, IFuncSqrt, IFuncTan, IFuncTanH, IInv, IMod, IMul,
+    INeg, INot, IPrintFunc, IVar, IAND, IEQ, IGT, IGTE, ILT, ILTE, INE, IOR,
 };
 use fasteval2::compiler::IC;
 #[cfg(feature = "eval-builtin")]
@@ -1338,6 +1338,15 @@ fn all_instrs() {
     comp_chk(
         "atanh(w)",
         IFuncATanH(InstructionI(0)),
+        "CompileSlab{ instrs:{ 0:IVar(\"w\") } }",
+        0.0,
+    );
+
+    // IFuncSqrt
+    comp_chk("sqrt(0)", IConst(0.0), "CompileSlab{ instrs:{} }", 0.0);
+    comp_chk(
+        "sqrt(w)",
+        IFuncSqrt(InstructionI(0)),
         "CompileSlab{ instrs:{ 0:IVar(\"w\") } }",
         0.0,
     );

--- a/tests/compile.rs
+++ b/tests/compile.rs
@@ -4,15 +4,22 @@ use fasteval2::compiler::Instruction::{
     self, IAdd, IConst, IExp, IFuncACos, IFuncACosH, IFuncASin, IFuncASinH, IFuncATan, IFuncATanH,
     IFuncAbs, IFuncCeil, IFuncCos, IFuncCosH, IFuncFloor, IFuncInt, IFuncLog, IFuncMax, IFuncMin,
     IFuncRound, IFuncSign, IFuncSin, IFuncSinH, IFuncSqrt, IFuncTan, IFuncTanH, IInv, IMod, IMul,
-    INeg, INot, IPrintFunc, IVar, IAND, IEQ, IGT, IGTE, ILT, ILTE, INE, IOR,
+    INeg, INot, IVar, IAND, IEQ, IGT, IGTE, ILT, ILTE, INE, IOR,
 };
+
+#[cfg(feature = "print-func")]
+use fasteval2::{
+    compiler::Instruction::IPrintFunc,
+    parser::{
+        ExpressionOrString::{EExpr, EStr},
+        PrintFunc,
+    },
+};
+
 use fasteval2::compiler::IC;
 #[cfg(feature = "eval-builtin")]
 use fasteval2::parser::{EvalFunc, KWArg};
-use fasteval2::parser::{
-    ExpressionOrString::{EExpr, EStr},
-    PrintFunc,
-};
+
 use fasteval2::{
     eval_compiled, eval_compiled_ref, CachedCallbackNamespace, Compiler, EmptyNamespace, Error,
     Evaler, ExpressionI, InstructionI, Parser, Slab,
@@ -913,8 +920,11 @@ fn all_instrs() {
         let (_s, i) = comp("int");
         assert_eq!(i, IVar("int".to_string()));
 
-        let (_s, i) = comp("print");
-        assert_eq!(i, IVar("print".to_string()));
+        #[cfg(feature = "print-func")]
+        {
+            let (_s, i) = comp("print");
+            assert_eq!(i, IVar("print".to_string()));
+        }
 
         let (_s, i) = comp("eval");
         assert_eq!(i, IVar("eval".to_string()));
@@ -1352,6 +1362,7 @@ fn all_instrs() {
     );
 
     // IPrintFunc
+    #[cfg(feature = "print-func")]
     comp_chk(
         r#"print("test",1.23)"#,
         IPrintFunc(PrintFunc(vec![

--- a/tests/compile.rs
+++ b/tests/compile.rs
@@ -481,9 +481,9 @@ fn all_instrs() {
     comp_chk("4 ^ 0.5", IConst(2.0), "CompileSlab{ instrs:{} }", 2.0);
     comp_chk(
         "2 ^ 0.5",
-        IConst(1.4142135623730951),
+        IConst(std::f64::consts::SQRT_2),
         "CompileSlab{ instrs:{} }",
-        1.4142135623730951,
+        std::f64::consts::SQRT_2,
     );
     comp_chk_str(
         "-4 ^ 0.5",
@@ -498,7 +498,7 @@ fn all_instrs() {
             power: IC::C(0.5),
         },
         "CompileSlab{ instrs:{ 0:IVar(\"y\") } }",
-        1.4142135623730951,
+        std::f64::consts::SQRT_2,
     );
     comp_chk(
         "2 ^ 3 ^ 2",
@@ -1038,15 +1038,15 @@ fn all_instrs() {
     comp_chk("log(10)", IConst(1.0), "CompileSlab{ instrs:{} }", 1.0);
     comp_chk(
         "log(2, 10)",
-        IConst(3.321928094887362),
+        IConst(std::f64::consts::LOG2_10),
         "CompileSlab{ instrs:{} }",
-        3.321928094887362,
+        std::f64::consts::LOG2_10,
     );
     comp_chk(
         "log(e(), 10)",
-        IConst(2.302585092994046),
+        IConst(std::f64::consts::LN_10),
         "CompileSlab{ instrs:{} }",
-        2.302585092994046,
+        std::f64::consts::LN_10,
     );
     comp_chk(
         "log(x)",
@@ -1278,15 +1278,15 @@ fn all_instrs() {
     // IFuncACos
     comp_chk(
         "acos(0)",
-        IConst(1.5707963267948966),
+        IConst(std::f64::consts::FRAC_PI_2),
         "CompileSlab{ instrs:{} }",
-        1.5707963267948966,
+        std::f64::consts::FRAC_PI_2,
     );
     comp_chk(
         "acos(w)",
         IFuncACos(InstructionI(0)),
         "CompileSlab{ instrs:{ 0:IVar(\"w\") } }",
-        1.5707963267948966,
+        std::f64::consts::FRAC_PI_2,
     );
 
     // IFuncATan

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -401,7 +401,7 @@ fn aaa_basics() {
             .unwrap()
             .from(&slab.ps)
             .eval(&slab, &mut ns),
-        Ok(2.718281828459045)
+        Ok(std::f64::consts::E)
     );
     assert_eq!(
         Parser::new()
@@ -409,7 +409,7 @@ fn aaa_basics() {
             .unwrap()
             .from(&slab.ps)
             .eval(&slab, &mut ns),
-        Ok(3.141592653589793)
+        Ok(std::f64::consts::PI)
     );
 
     assert_eq!(
@@ -442,7 +442,7 @@ fn aaa_basics() {
             .unwrap()
             .from(&slab.ps)
             .eval(&slab, &mut ns),
-        Ok(1.5707963267948966)
+        Ok(std::f64::consts::FRAC_PI_2)
     );
     assert_eq!(
         Parser::new()
@@ -450,7 +450,7 @@ fn aaa_basics() {
             .unwrap()
             .from(&slab.ps)
             .eval(&slab, &mut ns),
-        Ok(1.5707963267948966)
+        Ok(std::f64::consts::FRAC_PI_2)
     );
     assert_eq!(
         Parser::new()
@@ -458,7 +458,7 @@ fn aaa_basics() {
             .unwrap()
             .from(&slab.ps)
             .eval(&slab, &mut ns),
-        Ok(0.7853981633974483)
+        Ok(std::f64::consts::FRAC_PI_4)
     );
     assert_eq!(
         Parser::new()

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -486,7 +486,7 @@ fn aaa_basics() {
     );
 }
 
-//// Commented out until we bring CachedLayeredNamespace back.
+/// Commented out until we bring CachedLayeredNamespace back.
 // #[derive(Debug)]
 // struct TestEvaler;
 // impl Evaler for TestEvaler {
@@ -566,9 +566,9 @@ fn custom_func() {
             "x" => Some(1.0),
             "y" => Some(2.0),
             "z" => Some(3.0),
-            "foo" => Some(args.get(0).unwrap_or(&std::f64::NAN) * 10.0),
+            "foo" => Some(args.first().unwrap_or(&std::f64::NAN) * 10.0),
             "bar" => {
-                Some(args.get(0).unwrap_or(&std::f64::NAN) + args.get(1).unwrap_or(&std::f64::NAN))
+                Some(args.first().unwrap_or(&std::f64::NAN) + args.get(1).unwrap_or(&std::f64::NAN))
             }
             _ => None,
         }

--- a/tests/evalns.rs
+++ b/tests/evalns.rs
@@ -128,7 +128,7 @@ fn custom_vector_funcs() {
     ns.insert(
         "vec_sum",
         Box::new(|args| {
-            if let Some(index) = args.get(0) {
+            if let Some(index) = args.first() {
                 if let Some(v) = vecs_cell.borrow().get(*index as usize) {
                     return v.iter().sum();
                 }

--- a/tests/from_go.rs
+++ b/tests/from_go.rs
@@ -8,10 +8,10 @@ use fasteval2::{
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
-fn parse_raw<'a>(s: &str, slab: &'a mut Slab) -> Result<ExpressionI, Error> {
+fn parse_raw(s: &str, slab: &mut Slab) -> Result<ExpressionI, Error> {
     Parser::new().parse(s, &mut slab.ps)
 }
-fn ok_parse<'a>(s: &str, slab: &'a mut Slab) -> ExpressionI {
+fn ok_parse(s: &str, slab: &mut Slab) -> ExpressionI {
     parse_raw(s, slab).unwrap()
 }
 
@@ -24,7 +24,7 @@ fn do_eval(s: &str) -> f64 {
         .unwrap()
 }
 
-//// TODO:
+/// TODO:
 // fn capture_stderr(f:&dyn Fn()) -> String {
 //     f();
 //     "".to_string()

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -21,12 +21,14 @@ fn basics() {
     assert_eq!(format!("{:?}",&slab),
 "Slab{ exprs:{ 0:Expression { first: EConstant(-43.0), pairs: [ExprPair(ESub, EConstant(0.21))] }, 1:Expression { first: EConstant(12.34), pairs: [ExprPair(EAdd, EStdFunc(EFuncAbs(ExpressionI(0)))), ExprPair(EAdd, EConstant(11.11))] } }, vals:{}, instrs:{} }");
 
+    #[cfg(feature = "print-func")]
     Parser::new()
         .parse("12.34 + print ( 43.21 ) + 11.11", &mut slab.ps)
         .unwrap();
     assert_eq!(format!("{:?}",&slab),
 "Slab{ exprs:{ 0:Expression { first: EConstant(43.21), pairs: [] }, 1:Expression { first: EConstant(12.34), pairs: [ExprPair(EAdd, EPrintFunc(PrintFunc([EExpr(ExpressionI(0))]))), ExprPair(EAdd, EConstant(11.11))] } }, vals:{}, instrs:{} }");
 
+    #[cfg(feature = "print-func")]
     Parser::new()
         .parse("12.34 + print [ 43.21 ] + 11.11", &mut slab.ps)
         .unwrap();


### PR DESCRIPTION
This adds a builtin `sqrt` function, applies clippy fixes, adds a `print-func` feature which can be used to toggle the builtin `print` function (prints a value to stdout) and bumps the version to 2.0.4.